### PR TITLE
Correcting error identified by @smkuhlani in the creation of experimental files

### DIFF
--- a/potentialyield/Script/generic/DSSAT/dssat_expfile_zone.R
+++ b/potentialyield/Script/generic/DSSAT/dssat_expfile_zone.R
@@ -61,7 +61,7 @@ create_filex <-function(i,path.to.temdata,filex_temp,path.to.extdata,coords, AOI
   #Set the experimental directory
   if(AOI==TRUE){
     #setwd(paste(path.to.extdata,"AOI",paste0('EXTE', formatC(width = 4, (as.integer(i)), flag = "0")), sep = "/"))
-    setwd(paste(path.to.extdata,paste0(zone,'/EXTE', formatC(width = 4, (as.integer(i)), flag = "0")), sep = "/"))
+    setwd(paste(path.to.extdata,paste0(zone,"/",level2,'/EXTE', formatC(width = 4, (as.integer(i)), flag = "0")), sep = "/"))
     #Make proposed changes to FileX
     file_x$FIELDS$WSTA<-paste0("WHTE", formatC(width = 4, as.integer((i)), flag = "0"))
     file_x$FIELDS$ID_SOIL<-paste0('TRAN', formatC(width = 5, as.integer((i)), flag = "0"))


### PR DESCRIPTION
We were missing the parameter `level2 ` so the function `dssat.expfile` was not  creating the experimental files when `AOI= TRUE`  